### PR TITLE
Potential fix for code scanning alert no. 42: Clear-text logging of sensitive information

### DIFF
--- a/ucs-test-ucsschool/modules/univention/testing/ucsschool/user.py
+++ b/ucs-test-ucsschool/modules/univention/testing/ucsschool/user.py
@@ -259,7 +259,11 @@ class User(Person):
 
         param = [{"object": object_props, "options": None}]
         print("#### Editing user %s" % (self.username,))
-        print("#### param = %s" % (param,))
+        sanitized_param = param.copy()
+        for entry in sanitized_param:
+            if "object" in entry and "password" in entry["object"]:
+                entry["object"]["password"] = "REDACTED"
+        print("#### param = %s" % (sanitized_param,))
         reqResult = self.client.umc_command("schoolwizards/users/put", param, flavor).result
         assert reqResult[0] is True, "Unable to edit user (%s) with the parameters (%r) : %r" % (
             self.username,


### PR DESCRIPTION
Potential fix for [https://github.com/geekswagg/ucs-school/security/code-scanning/42](https://github.com/geekswagg/ucs-school/security/code-scanning/42)

To fix the issue, sensitive data such as passwords should be excluded from the log output. Instead of logging the entire `param` object, the code should log only non-sensitive information or redact sensitive fields before logging. This ensures that sensitive data is not exposed while retaining useful debugging information.

The fix involves:
1. Redacting the `password` field from the `param` object before logging.
2. Modifying the `print` statement on line 262 to log the sanitized version of `param`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
